### PR TITLE
1.8.0 - 1.12.2 & nicer button

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 archivesBaseName = project.archives_base_name
-version = "${project.mod_version}+${project.minecraft_version}" as Object
+version = "${project.mod_version}" as Object
 group = project.maven_group
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,6 @@ yarn_mappings = 1.8.9+build.202201091851
 loader_version = 0.12.12
 
 # Mod Properties
-mod_version = 1.0.2
+mod_version = 1.0.3
 maven_group = me.voidxwalker
 archives_base_name = anchiale

--- a/src/main/java/me/voidxwalker/anchiale/Anchiale.java
+++ b/src/main/java/me/voidxwalker/anchiale/Anchiale.java
@@ -1,14 +1,9 @@
 package me.voidxwalker.anchiale;
 
-import net.fabricmc.api.ClientModInitializer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class Anchiale implements ClientModInitializer {
+public class Anchiale {
     public static final Logger LOGGER = LogManager.getLogger();
     public static boolean fastReset = false;
-    @Override
-    public void onInitializeClient() {
-
-    }
 }

--- a/src/main/java/me/voidxwalker/anchiale/mixin/GameMenuScreenMixin.java
+++ b/src/main/java/me/voidxwalker/anchiale/mixin/GameMenuScreenMixin.java
@@ -3,42 +3,32 @@ package me.voidxwalker.anchiale.mixin;
 import me.voidxwalker.anchiale.Anchiale;
 import net.minecraft.client.gui.screen.GameMenuScreen;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.TitleScreen;
-import net.minecraft.client.gui.screen.multiplayer.MultiplayerScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.resource.language.I18n;
-import net.minecraft.client.world.ClientWorld;
-import net.minecraft.realms.RealmsBridge;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(GameMenuScreen.class)
-public class GameMenuScreenMixin extends Screen {
+public abstract class GameMenuScreenMixin extends Screen {
+
+    @Shadow protected abstract void buttonClicked(ButtonWidget button);
+
     @Inject(method = "init", at = @At("TAIL"))
     private void addMenuQuitWorldButton(CallbackInfo ci) {
-        this.buttons.add(new ButtonWidget(1507, this.width - 200, this.height - 20, I18n.translate("menu.quitWorld")));
+        String menuQuitWorld = I18n.translate("menu.quitWorld");
+        int width = this.textRenderer.getStringWidth(menuQuitWorld) + 30;
+        this.buttons.add(new ButtonWidget(1507, this.width - width - 5, this.height - 25, width, 20, menuQuitWorld));
     }
 
     @Inject(method = "buttonClicked", at = @At("HEAD"), cancellable = true)
     private void onMenuQuitWorldClicked(ButtonWidget button, CallbackInfo ci) {
         if (button.id == 1507) {
             Anchiale.fastReset = true;
-            boolean bl = this.client.isIntegratedServerRunning();
-            boolean bl2 = this.client.isConnectedToRealms();
-            button.active = false;
-            this.client.world.disconnect();
-            this.client.connect((ClientWorld)null);
+            this.buttonClicked(this.buttons.get(0));
             Anchiale.fastReset = false;
-            if (bl) {
-                this.client.openScreen(new TitleScreen());
-            } else if (bl2) {
-                RealmsBridge realmsBridge = new RealmsBridge();
-                realmsBridge.switchToRealms(new TitleScreen());
-            } else {
-                this.client.openScreen(new MultiplayerScreen(new TitleScreen()));
-            }
             ci.cancel();
         }
     }

--- a/src/main/java/me/voidxwalker/anchiale/mixin/IntegratedServerMixin.java
+++ b/src/main/java/me/voidxwalker/anchiale/mixin/IntegratedServerMixin.java
@@ -1,23 +1,15 @@
 package me.voidxwalker.anchiale.mixin;
 
-import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import me.voidxwalker.anchiale.Anchiale;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.integrated.IntegratedServer;
-import net.minecraft.server.network.ServerPlayerEntity;
-import org.apache.commons.lang3.Validate;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 import java.io.File;
 import java.net.Proxy;
-import java.util.Iterator;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 @Mixin(IntegratedServer.class)
@@ -34,18 +26,7 @@ public abstract class IntegratedServerMixin<V> extends MinecraftServer {
             return null;
         } else {
             Anchiale.LOGGER.info("Exiting world normally.");
-            Futures.getUnchecked(this.execute(new Runnable() {
-                public void run() {
-                    List<ServerPlayerEntity> list = Lists.newArrayList((Iterable)IntegratedServerMixin.this.getPlayerManager().getPlayers());
-                    Iterator iterator = list.iterator();
-
-                    while(iterator.hasNext()) {
-                        ServerPlayerEntity serverPlayerEntity = (ServerPlayerEntity)iterator.next();
-                        IntegratedServerMixin.this.getPlayerManager().remove(serverPlayerEntity);
-                    }
-                }
-            }));
+            return Futures.getUnchecked(e);
         }
-        return null;
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -4,11 +4,6 @@
   "version": "${version}",
   "name": "Anchiale",
   "description": "",
-  "entrypoints": {
-    "client": [
-      "me.voidxwalker.anchiale.Anchiale"
-    ]
-  },
   "authors": [
     "RedLime?",
     "voidxwalker",
@@ -22,6 +17,6 @@
   ],
   "depends": {
     "fabricloader": ">=0.12.12",
-    "minecraft": "1.8.9"
+    "minecraft": ">=1.8 <=1.12.2"
   }
 }


### PR DESCRIPTION
adds compatibility for versions 1.8.0 to 1.12.2
i know the effects get less and less noticable as the versions progress but it was compatible anyway and still has a (very small however in 1.12) impact so i just included it cuz why not

also makes the button render smaller (adjusting to the translation string size) and not touch the edge of the window, making it more like the fastreset button